### PR TITLE
Fix crash when thread is different to main.

### DIFF
--- a/src/modules/Core/Notification Controller/Main Controller/DNNotificationController.m
+++ b/src/modules/Core/Notification Controller/Main Controller/DNNotificationController.m
@@ -62,15 +62,21 @@ static NSString *const DNNotificationRichController = @"DRLogicMainController";
         DNErrorLog(@"Can only add categories in iOS 8.0 and above...");
         return;
     }
+    if ([NSThread isMainThread]) {
+        [self registerNotificationsHelperMethod:categories];
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self registerNotificationsHelperMethod:categories];
+        });
+    }
+}
 
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
-                                                                             settingsForTypes:(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge)
-                                                                             categories:categories]];
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-    });
++ (void)registerNotificationsHelperMethod:(NSMutableSet *)categories {
+    [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
+                                                                         settingsForTypes:(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge)
+                                                                         categories:categories]];
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
 
-    
 }
 
 + (void)registerDeviceToken:(NSData *)token {


### PR DESCRIPTION
Current SDK assumes background thread when registering for categories of notifications in-app, but this may not always be the case - this PR adds a check for which thread the category registration is running on.